### PR TITLE
Add support for Azure, OpenAI, Palm, Anthropic, Cohere, Replicate Models - using litellm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ authors = [
 dependencies = [
     "rich>=13.3.1",
     "openai>=0.27.0",
+    "litellm>=0.1.351",
     "pysocks>=1.7.1",
     "pyperclip>=1.8.2",
     "EdgeGPT>=0.1.22.1",

--- a/src/ai_cli/bot/__init__.py
+++ b/src/ai_cli/bot/__init__.py
@@ -7,6 +7,7 @@ from typing import Generator, Union
 from uuid import uuid4
 
 import openai
+from litellm import completion
 
 from ai_cli.bot.token import get_token_count
 from ai_cli.setting import Setting
@@ -145,7 +146,7 @@ class GPTBot(Bot):
         messages = list(self.get_messages())
         logger.debug(f"Messages: {messages}, model: {self.model}, stream: {stream}")
         try:
-            response = openai.ChatCompletion.create(model=self.model, messages=messages, stream=stream)
+            response = completion(model=self.model, messages=messages, stream=stream)
             if not stream:
                 yield response.choices[0].message.content
             else:


### PR DESCRIPTION
This PR adds support for models from all the above mentioned providers using litellm https://github.com/BerriAI/litellm - a simple & light package to call OpenAI, Azure, Cohere, Anthropic API Endpoints

Here's a sample of how it's used:

```
from litellm import completion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```